### PR TITLE
FreeBSD Compatibility

### DIFF
--- a/pxyconn.c
+++ b/pxyconn.c
@@ -938,7 +938,7 @@ pxy_try_remove_sslproxy_header(pxy_conn_child_ctx_t *ctx, unsigned char *packet,
 	}
 }
 
-#ifdef __APPLE__
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #define getdtablecount() 0
 
 /*

--- a/pxyconn.h
+++ b/pxyconn.h
@@ -30,6 +30,10 @@
 #ifndef PXYCONN_H
 #define PXYCONN_H
 
+#if defined(__FreeBSD__) || defined(__DragonFly__)
+#include <netinet/in.h>
+#endif
+
 #include "proxy.h"
 #include "opts.h"
 #include "attrib.h"


### PR DESCRIPTION
For sockaddr_in FreeBSD needs netinet/in.h