### PR TITLE
Use CLOCK_REALTIME to fix pcap timestamp issue

### DIFF
--- a/src/logpkt.c
+++ b/src/logpkt.c
@@ -301,7 +301,7 @@ logpkt_pcap_write(const uint8_t *pkt, size_t pktsz, int fd)
 	pcap_rec_hdr_t rec_hdr;
 	struct timespec tv;
 
-	if (clock_gettime(CLOCK_MONOTONIC, &tv) == -1)
+	if (clock_gettime(CLOCK_REALTIME, &tv) == -1)
 	{
 		log_err_printf("Error getting current time: %s\n",
 		               strerror(errno));

--- a/src/sys.c
+++ b/src/sys.c
@@ -1017,7 +1017,7 @@ static void
 sys_rand_seed(void) {
 	struct timespec seed;
 
-	if (clock_gettime(CLOCK_MONOTONIC, &seed) == -1) {
+	if (clock_gettime(CLOCK_REALTIME, &seed) == -1) {
 		srandom((unsigned)time(NULL));
 	} else {
 		srandom((unsigned)(seed.tv_sec ^ seed.tv_nsec));


### PR DESCRIPTION
Recent changes removed `gettimeofday()` and replaced it with `clock_gettime()`. The `CLOCK_MONOTONIC` clock identifier was also introduced. Timestamps from this clock (on Linux) are relative to system boot time. This results in pcaps with packet records (as evidenced by `tcpdump -tttt`) with the boot-relative times getting [added to the Epoch](https://wiki.wireshark.org/Development/LibpcapFileFormat#record-packet-header), resulting in inaccurate absolute times (e.g., a pcap from a machine booted for a 2 days resulted in packet records with date 1970-01-03).

This MR introduces `CLOCK_REALTIME` which results [in wall time since the Epoch](https://linux.die.net/man/3/clock_gettime).