### PR TITLE
Fix AutoSSL connections stalling on pass rules by falling back to passthrough

### DIFF
--- a/src/protopassthrough.c
+++ b/src/protopassthrough.c
@@ -258,8 +258,13 @@ protopassthrough_bev_eventcb_connected_srvdst(struct bufferevent *bev, pxy_conn_
 	bufferevent_enable(bev, EV_READ|EV_WRITE);
 
 	// Do not re-enable src if it is already enabled, e.g. in autossl
-	if (!ctx->src.bev && protopassthrough_enable_src(ctx) == -1) {
-		return;
+	if (!ctx->src.bev) {
+		if (protopassthrough_enable_src(ctx) == -1) {
+			return;
+		}
+	} else if (evbuffer_get_length(bufferevent_get_input(ctx->src.bev)) > 0) {
+		log_finer("src inbuf len > 0, calling bev_readcb for src");
+		ctx->protoctx->bev_readcb(ctx->src.bev, ctx);
 	}
 }
 

--- a/src/protossl.c
+++ b/src/protossl.c
@@ -1604,6 +1604,12 @@ protossl_setup_src_ssl_from_dst(pxy_conn_ctx_t *ctx)
 	else if (ctx->term) {
 		return -1;
 	}
+	else if (!ctx->enomem && (ctx->pass || ctx->conn_opts->passthrough)) {
+		log_err_level_printf(LOG_WARNING, "Falling back to passthrough\n");
+		protopassthrough_engage(ctx);
+		// report protocol change by returning 1
+		return 1;
+	}
 	pxy_conn_term(ctx, 1);
 	return -1;
 }
@@ -1618,6 +1624,12 @@ protossl_setup_src_ssl_from_child_dst(pxy_conn_child_ctx_t *ctx)
 	}
 	else if (ctx->conn->term) {
 		return -1;
+	}
+	else if (!ctx->conn->enomem && (ctx->conn->pass || ctx->conn->conn_opts->passthrough)) {
+		log_err_level_printf(LOG_WARNING, "Falling back to passthrough\n");
+		protopassthrough_engage(ctx->conn);
+		// report protocol change by returning 1
+		return 1;
 	}
 	pxy_conn_term(ctx->conn, 1);
 	return -1;


### PR DESCRIPTION
## Description

- **What does this PR do?**
  This PR updates the protocol handling logic to correctly fall back to the passthrough protocol when a `pass` rule or passthrough option is configured during AutoSSL connections.

- **What problem does it solve or what feature does it add?**
  It fixes an issue where AutoSSL connections would stall when a `pass` rule was matched. Previously, the connection would stall or terminate. Now, it falls back to passthrough and ensures that any buffered client (source) data is properly processed after switching protocols.

- **Is this related to an open issue? If so, reference it here.**
  N/A

## Checklist

- [x] I have read and agreed to the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] My code builds and passes all tests (`make test` or equivalent).
- [ ] I have added or updated documentation as needed. *(N/A - bug fix)*
- [x] I have tested the changes and verified new and existing functionality works as expected.

## Additional Information

- **Any special instructions for testing?**
  To verify, configure an AutoSSL setup with a `pass` rule for a specific connection. Ensure that the connection succeeds and does not stall, and that any initial data sent by the client before the protocol switch is correctly forwarded.
  
- **Screenshots, logs, or other supporting materials, if applicable.**
  When the fallback occurs, a warning log `Falling back to passthrough` will be recorded, and the source buffer will be checked and processed if its length > 0.